### PR TITLE
Patch meson.build to use install_rpath

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/0001-Add-install_rpath-to-meson.build.patch
+++ b/recipe/0001-Add-install_rpath-to-meson.build.patch
@@ -1,0 +1,15 @@
+--- orc/meson.build
++++ orc/meson.build
+@@ -111,3 +111,4 @@
+   dependencies : orc_dependencies,
+-  install : true)
++  install : true,
++  install_rpath : join_paths(get_option('prefix'), get_option('libdir')))
+
+--- orc-test/meson.build
++++ orc-test/meson.build
+@@ -13,3 +13,4 @@
+   dependencies : [libm, orc_dep],
+-  install : true)
++  install : true,
++  install_rpath : join_paths(get_option('prefix'), get_option('libdir')))

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-meson setup buildir --prefix=${PREFIX} --libdir=${PREFIX}/lib
+meson setup buildir --prefix=${PREFIX} --libdir=lib
 ninja -C buildir
 ninja -C buildir install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,12 @@ requirements:
     - meson
 
 test:
+  requires:
+    - chrpath  # [linux]
   commands:
     - test -f ${PREFIX}/lib/liborc-0.4${SHLIB_EXT}  # [unix]
+    - chrpath -l ${PREFIX}/lib/liborc-0.4.so      | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
+    - chrpath -l ${PREFIX}/lib/liborc-0.4-test.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
     - orcc --help
     - orc-bugreport --help
  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
  
 about:
   home: https://gstreamer.freedesktop.org/modules/orc.html
-  license: Custom
+  license: BSD-2-Clause AND BSD-3-Clause
   license_file: COPYING
   summary: 'Optimized Inner Loop Runtime Compiler'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://gstreamer.freedesktop.org/data/src/orc/orc-{{version}}.tar.xz
   sha256: a0ab5f10a6a9ae7c3a6b4218246564c3bf00d657cbdf587e6d34ec3ef0616075
+  patches:
+    - 0001-Add-install_rpath-to-meson.build.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ test:
   commands:
     - test -f ${PREFIX}/lib/liborc-0.4${SHLIB_EXT}  # [unix]
     - chrpath -l ${PREFIX}/lib/liborc-0.4.so      | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
-    - chrpath -l ${PREFIX}/lib/liborc-0.4-test.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
+    - chrpath -l ${PREFIX}/lib/liborc-test-0.4.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
     - orcc --help
     - orc-bugreport --help
  


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
fixes gh-3
<!--
Please add any other relevant info below:
-->
Thanks to @kleisauke for the patch.

cc @sebastian-luna-valero, @kleisauke