### PR TITLE
Add platforms (osx-arm64, Windows, linux-aarch64, linux-ppc64)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,8 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,7 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,110 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
+    matrix:
+      win_64_:
+        CONFIG: win_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+
+  steps:
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: true
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    
+
+    # Special cased version setting some more things!
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe (vs2008)
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,12 +1,17 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,18 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,14 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,14 +1,14 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/rust_dev,conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 target_platform:
-- osx-64
+- osx-arm64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,0 +1,8 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+target_platform:
+- win-64

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,31 @@
+---
+kind: pipeline
+name: linux_aarch64_
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sebastian-luna-valero
+* @ryanvolz @sebastian-luna-valero

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -6,8 +6,15 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
-export PYTHONUNBUFFERED=1
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
+
+
+( endgroup "Start Docker" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+
+export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
@@ -18,8 +25,9 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
+BUILD_CMD=build
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -29,13 +37,42 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "${FEEDSTOCK_NAME}"
-
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
+
+
+( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
+fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
+        * )
+            echo "$1";;
+    esac
+} 2> /dev/null
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
+    esac
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+( startgroup "Configure Docker" ) 2> /dev/null
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -45,10 +49,14 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
+        fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 
@@ -62,10 +70,14 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
@@ -74,6 +86,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
@@ -83,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,57 +1,73 @@
 #!/usr/bin/env bash
 
-set -x
+source .scripts/logging_utils.sh
 
-echo -e "\n\nInstalling a fresh version of Miniforge."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:install_miniforge\\r'
-fi
+set -xe
+
+MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+
+( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-bash $MINIFORGE_FILE -b
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:install_miniforge\\r'
-fi
+bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
-echo -e "\n\nConfiguring conda."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:configure_conda\\r'
-fi
+( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
-source ${HOME}/miniforge3/etc/profile.d/conda.sh
+( startgroup "Configuring conda" ) 2> /dev/null
+
+BUILD_CMD=build
+
+source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
 
 
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
-mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
 
-echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
-/usr/bin/sudo mangle_homebrew
-/usr/bin/sudo -k
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
 
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 
 
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:configure_conda\\r'
-fi
 
-set -e
+( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file and running the build."
+
+echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
+conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+( startgroup "Validating outputs" ) 2> /dev/null
+
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
+( endgroup "Validating outputs" ) 2> /dev/null
+
+( startgroup "Uploading packages" ) 2> /dev/null
+
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  echo -e "\n\nUploading the packages."
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi
+
+( endgroup "Uploading packages" ) 2> /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/gstreamer-orc-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/gstreamer-orc-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr><tr>
+    <td>Drone</td>
+    <td>
+      <a href="https://cloud.drone.io/conda-forge/gstreamer-orc-feedstock">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/gstreamer-orc-feedstock/master.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -31,6 +45,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7482&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7482&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7482&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -148,5 +176,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@ryanvolz](https://github.com/ryanvolz/)
 * [@sebastian-luna-valero](https://github.com/sebastian-luna-valero/)
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: https://gstreamer.freedesktop.org/modules/orc.html
 
 Package license: BSD-2-Clause AND BSD-3-Clause
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gstreamer-orc-feedstock/blob/master/LICENSE.txt)
 
 Summary: Optimized Inner Loop Runtime Compiler
-
-
 
 Current build status
 ====================
@@ -42,6 +40,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7482&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -64,6 +69,7 @@ Installing `gstreamer-orc` from the `conda-forge` channel can be achieved by add
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `gstreamer-orc` can be installed with:
@@ -134,9 +140,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7482&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstreamer-orc-feedstock?branchName=master&jobName=win&configuration=win_64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -7,15 +7,29 @@ import os
 import glob
 import subprocess
 from argparse import ArgumentParser
+import platform
 
 
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
+    if "MINIFORGE_HOME" not in os.environ:
+        os.environ["MINIFORGE_HOME"] = os.path.join(
+            os.path.dirname(__file__), "miniforge3"
+        )
 
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"
+    subprocess.check_call([script])
+
+
+def run_osx_build(ns):
+    script = ".scripts/run_osx_build.sh"
     subprocess.check_call([script])
 
 
@@ -42,21 +56,40 @@ def verify_config(ns):
     else:
         raise ValueError("config " + ns.config + " is not valid")
     # Remove the following, as implemented
-    if not ns.config.startswith("linux"):
+    if ns.config.startswith("win"):
         raise ValueError(
-            f"only Linux configs currently supported, got {ns.config}"
+            f"only Linux/macOS configs currently supported, got {ns.config}"
         )
+    elif ns.config.startswith("osx") and platform.system() == "Darwin":
+        if "OSX_SDK_DIR" not in os.environ:
+            raise RuntimeError(
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=/opt'"
+                "to download the SDK automatically to '/opt/MacOSX<ver>.sdk'"
+            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)
     setup_environment(ns)
 
-    run_docker_build(ns)
+    if ns.config.startswith("linux") or (
+        ns.config.startswith("osx") and platform.system() == "Linux"
+    ):
+        run_docker_build(ns)
+    elif ns.config.startswith("osx"):
+        run_osx_build(ns)
 
 
 if __name__ == "__main__":

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,4 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
+provider: {linux_aarch64: default, linux_ppc64le: default}
 test_on_native_only: true

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,3 @@
+build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
+test_on_native_only: true

--- a/recipe/0002-Fix-powerpc-build-with-kernel-lt-411.patch
+++ b/recipe/0002-Fix-powerpc-build-with-kernel-lt-411.patch
@@ -1,0 +1,66 @@
+From dc44b05bfb2f437ce15d28c950fac0b0cf061cbe Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Mon, 15 Feb 2021 20:17:43 +0100
+Subject: [PATCH] orc/orccpu-powerpc.c: fix build with kernel < 4.11
+
+Build with powerpc and kernel < 4.11 is broken since version 0.4.30 and
+https://gitlab.freedesktop.org/gstreamer/orc/-/commit/a999325abea6a5549d60d99ddeb0271d2aa00235:
+
+FAILED: orc/liborc-0.4.so.0.32.0.p/orccpu-powerpc.c.o
+/home/giuliobenetti/autobuild/run/instance-3/output-1/host/bin/powerpc-linux-gcc -Iorc/liborc-0.4.so.0.32.0.p -Iorc -I../orc -I. -I.. -fdiagnostics-color=always -pipe -Wall -Winvalid-pch -std=gnu99 -O3 -DHAVE_CONFIG_H -fvisibility=hidden -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -fPIC -pthread -DORC_ENABLE_UNSTABLE_API -D_GNU_SOURCE -DBUILDING_ORC -MD -MQ orc/liborc-0.4.so.0.32.0.p/orccpu-powerpc.c.o -MF orc/liborc-0.4.so.0.32.0.p/orccpu-powerpc.c.o.d -o orc/liborc-0.4.so.0.32.0.p/orccpu-powerpc.c.o -c ../orc/orccpu-powerpc.c
+../orc/orccpu-powerpc.c: In function 'orc_check_powerpc_proc_auxv':
+../orc/orccpu-powerpc.c:164:21: error: 'AT_L1D_CACHESIZE' undeclared (first use in this function); did you mean 'AT_DCACHEBSIZE'?
+  164 |       if (buf[i] == AT_L1D_CACHESIZE) {
+      |                     ^~~~~~~~~~~~~~~~
+      |                     AT_DCACHEBSIZE
+../orc/orccpu-powerpc.c:164:21: note: each undeclared identifier is reported only once for each function it appears in
+../orc/orccpu-powerpc.c:168:21: error: 'AT_L2_CACHESIZE' undeclared (first use in this function); did you mean 'AT_ICACHEBSIZE'?
+  168 |       if (buf[i] == AT_L2_CACHESIZE) {
+      |                     ^~~~~~~~~~~~~~~
+      |                     AT_ICACHEBSIZE
+../orc/orccpu-powerpc.c:172:21: error: 'AT_L3_CACHESIZE' undeclared (first use in this function); did you mean 'AT_ICACHEBSIZE'?
+  172 |       if (buf[i] == AT_L3_CACHESIZE) {
+      |                     ^~~~~~~~~~~~~~~
+      |                     AT_ICACHEBSIZE
+
+Indeed, AT_{L1D,L2,L3}_CACHESIZE is only defined since kernel 4.11 and
+https://github.com/torvalds/linux/commit/98a5f361b8625c6f4841d6ba013bbf0e80d08147
+
+Fixes:
+ - http://autobuild.buildroot.org/results/0821e96cba3e455edd47b87485501d892fc7ac6a
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/gstreamer/orc/-/merge_requests/56>
+---
+ orc/orccpu-powerpc.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/orc/orccpu-powerpc.c b/orc/orccpu-powerpc.c
+index 6796f17..340cf05 100644
+--- a/orc/orccpu-powerpc.c
++++ b/orc/orccpu-powerpc.c
+@@ -161,18 +161,24 @@ orc_check_powerpc_proc_auxv (void)
+         _orc_cpu_name = (char*)buf[i + 1];
+         found++;
+       }
++#ifdef AT_L1D_CACHESIZE
+       if (buf[i] == AT_L1D_CACHESIZE) {
+         _orc_data_cache_size_level1 = buf[i + 1];
+         found++;
+       }
++#endif
++#ifdef AT_L2_CACHESIZE
+       if (buf[i] == AT_L2_CACHESIZE) {
+         _orc_data_cache_size_level2 = buf[i + 1];
+         found++;
+       }
++#endif
++#ifdef AT_L3_CACHESIZE
+       if (buf[i] == AT_L3_CACHESIZE) {
+         _orc_data_cache_size_level3 = buf[i + 1];
+         found++;
+       }
++#endif
+       if (found == 6)
+         break;
+     }

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,3 +22,8 @@ if errorlevel 1 exit 1
 
 ninja -C forgebuild install -j %CPU_COUNT%
 if errorlevel 1 exit 1
+
+:: don't install static library (CFEP #18)
+:: (easier to remove it than patch to disable it in the build)
+del /q /f "%LIBRARY_LIB%\liborc*.a"
+if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,24 @@
+setlocal EnableExtensions EnableDelayedExpansion
+@echo on
+
+:: meson options
+:: (set pkg_config_path so deps in host env can be found)
+set ^"MESON_OPTIONS=^
+  --prefix="%LIBRARY_PREFIX%" ^
+  --buildtype=release ^
+  --backend=ninja ^
+ ^"
+
+:: configure build using meson
+meson setup forgebuild !MESON_OPTIONS!
+if errorlevel 1 exit 1
+
+:: print results of build configuration
+meson configure forgebuild
+if errorlevel 1 exit 1
+
+ninja -v -C forgebuild -j %CPU_COUNT%
+if errorlevel 1 exit 1
+
+ninja -C forgebuild install -j %CPU_COUNT%
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-meson setup buildir --prefix=${PREFIX} --libdir=lib
+meson setup buildir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib
 ninja -C buildir
 ninja -C buildir install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,3 +4,7 @@ set -eo pipefail
 meson setup buildir ${MESON_ARGS} --buildtype=release --prefix=${PREFIX} -Dlibdir=lib
 ninja -C buildir
 ninja -C buildir install
+
+# don't install static library (CFEP #18)
+# (easier to delete than patch source to not build it)
+rm -f $PREFIX/liborc-test*.a

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-meson setup buildir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib
+meson setup buildir ${MESON_ARGS} --buildtype=release --prefix=${PREFIX} -Dlibdir=lib
 ninja -C buildir
 ninja -C buildir install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 meson setup buildir ${MESON_ARGS} --buildtype=release --prefix=${PREFIX} -Dlibdir=lib
 ninja -C buildir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0002-Fix-powerpc-build-with-kernel-lt-411.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - meson
+    - ninja
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - chrpath  # [linux]
   commands:
     - test -f ${PREFIX}/lib/liborc-{{ majmin }}${SHLIB_EXT}  # [unix]
-    - if not exist %PREFIX%\\Library\\bin\\orc-{{ majmin }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\orc-{{ majmin }}-0.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\orc-{{ majmin }}.lib exit 1  # [win]
     - chrpath -l ${PREFIX}/lib/liborc-{{ majmin }}.so      | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
     - chrpath -l ${PREFIX}/lib/liborc-test-{{ majmin }}.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-  host:
     - meson
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,4 +38,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - ryanvolz
     - sebastian-luna-valero

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "gstreamer-orc" %}
 {% set version = "0.4.32" %}
+{% set majmin = ".".join(version.split(".")[:2]) %}
 
 package:
   name: {{ name|lower }}
@@ -24,9 +25,11 @@ test:
   requires:
     - chrpath  # [linux]
   commands:
-    - test -f ${PREFIX}/lib/liborc-0.4${SHLIB_EXT}  # [unix]
-    - chrpath -l ${PREFIX}/lib/liborc-0.4.so      | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
-    - chrpath -l ${PREFIX}/lib/liborc-test-0.4.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
+    - test -f ${PREFIX}/lib/liborc-{{ majmin }}${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\orc-{{ majmin }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\orc-{{ majmin }}.lib exit 1  # [win]
+    - chrpath -l ${PREFIX}/lib/liborc-{{ majmin }}.so      | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
+    - chrpath -l ${PREFIX}/lib/liborc-test-{{ majmin }}.so | grep -qF 'RPATH=$ORIGIN/.'  # [linux]
     - orcc --help
     - orc-bugreport --help
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   sha256: a66e3d8f2b7e65178d786a01ef61f2a0a0b4d0b8370de7ce134ba73da4af18f0
   patches:
     - 0001-Add-install_rpath-to-meson.build.patch
+    # next patch is upstream, should be able to remove after 0.4.32
+    - 0002-Fix-powerpc-build-with-kernel-lt-411.patch
 
 build:
   number: 0


### PR DESCRIPTION
I'm interested in adding support for the breadth of platforms that conda-forge supports, so I can use `gstreamer-orc` from `volk` which supports all of the platforms. I'm willing to volunteer as a maintainer to keep these going!

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
